### PR TITLE
V2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # DraftKings Python Client
 
+[![Build Status](https://travis-ci.org/jaebradley/draftkings_client.svg?branch=master)](https://travis-ci.org/jaebradley/draftkings_client)
+[![codecov](https://codecov.io/gh/jaebradley/draftkings_client/branch/master/graph/badge.svg)](https://codecov.io/gh/jaebradley/draftkings_client)
+![PyPI](https://img.shields.io/pypi/v/draft_kings.svg)
+
 ## Introduction
 DraftKings does not have a public API with documentation.
 
@@ -8,8 +12,14 @@ DraftKings - data like NFL contests, or players available for a
 "Draft Group" (e.g. all NBA games starting at 7 PM EST tonight), along
 with relevant metadata.
 
+As DraftKings makes no guarantees about it's public API, this client makes no guarantees that existing API methods
+will work consistently.
+
 ## Install using PyPi
-`pip install draft_kings`
+
+```bash
+pip install draft_kings
+```
 
 ## API
 
@@ -26,7 +36,7 @@ contests(sport=Sport.nba)
 ```python
 from draft_kings.client import available_players
 
-return available_players(draft_group_id=1)
+available_players(draft_group_id=1)
 ```
 
 ### Get Draft Group Details
@@ -34,7 +44,7 @@ return available_players(draft_group_id=1)
 ```python
 from draft_kings.client import draft_group_details
 
-return draft_group_details(draft_group_id=1)
+draft_group_details(draft_group_id=1)
 ```
 
 ### Get Countries
@@ -44,7 +54,7 @@ Get all country information that DraftKings uses to make country-specific reques
 ```python
 from draft_kings.client import countries
 
-return countries()
+countries()
 ```
 
 ### Get Regions
@@ -54,7 +64,7 @@ Get all region information for the specified country code that DraftKings uses t
 ```python
 from draft_kings.client import regions
 
-return regions(country_code='US')
+regions(country_code='US')
 ```
 
 
@@ -65,5 +75,5 @@ Get all draftable players
 ```python
 from draft_kings.client import draftables
 
-return draftables(draft_group_id=1)
+draftables(draft_group_id=1)
 ```

--- a/draft_kings/__init__.py
+++ b/draft_kings/__init__.py
@@ -1,1 +1,1 @@
-
+from draft_kings.data import Sport

--- a/draft_kings/client.py
+++ b/draft_kings/client.py
@@ -1,34 +1,13 @@
 import requests
 
 from draft_kings import urls
-from draft_kings.data import Sport
 from draft_kings.response_translators import translate_players, translate_contests, translate_countries, \
-    translate_draft_group, translate_regions, translate_draftables
-
-"""
-The API takes a sport query parameter that's different than then sports API endpoint
-"""
-SPORT_TO_CONTESTS_QUERY_PARAMETER = {
-    Sport.NFL: "NFL",
-    Sport.NHL: "NHL",
-    Sport.NBA: "NBA",
-    Sport.CFL: "CFL",
-    Sport.COLLEGE_FOOTBALL: "CFB",
-    Sport.MIXED_MARTIAL_ARTS: "MMA",
-    Sport.NASCAR: "NAS",
-    Sport.SOCCER: "SOC",
-    Sport.EUROLEAGUE_BASKETBALL: "EL",
-    Sport.MLB: "MLB",
-    Sport.TENNIS: "TEN",
-    Sport.LEAGUE_OF_LEGENDS: "LOL",
-    Sport.GOLF: "GOLF",
-    Sport.COLLEGE_BASKETBALL: "CBB"
-}
+    translate_draft_group, translate_regions, translate_draftables, SPORT_TO_CONTESTS_ABBREVIATION
 
 
 def contests(sport):
     response = requests.get(url=urls.CONTESTS_URL,
-                            params={'sport': SPORT_TO_CONTESTS_QUERY_PARAMETER[sport]})
+                            params={'sport': SPORT_TO_CONTESTS_ABBREVIATION[sport]})
 
     response.raise_for_status()
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="draft_kings",
-    version="2.0.0",
+    version="3.0.0",
     author="Jae Bradley",
     author_email="jae.b.bradley@gmail.com",
     license="MIT",

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="draft_kings",
-    version="3.0.0",
+    version="2.0.1",
     author="Jae Bradley",
     author_email="jae.b.bradley@gmail.com",
     license="MIT",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 
 from draft_kings.client import available_players, draft_group_details, draftables, regions, contests, countries
-from draft_kings.client import Sport
+from draft_kings.data import Sport
 
 
 class TestClient(TestCase):

--- a/tests/test_response_translators.py
+++ b/tests/test_response_translators.py
@@ -1,8 +1,11 @@
 import json
 import os
 from unittest import TestCase
+from datetime import datetime
+import pytz
 
 from draft_kings.response_translators import translate_contests, translate_contest
+from draft_kings.data import Sport
 from tests.config import ROOT_DIRECTORY
 
 
@@ -21,3 +24,15 @@ class TestContestResponseTranslator(TestCase):
             translation = translate_contest(data)
             self.assertIsNotNone(translation)
             self.assertEqual(translation["id"], 32099545)
+            self.assertFalse(translation["double_up"])
+            self.assertEqual(translation["draft_group_id"], 11435)
+            self.assertEqual(translation["entries"], {"maximum": 12261, "fee": 33.0, "total": 864})
+            self.assertEqual(translation["fantasy_player_points"], 33)
+            self.assertFalse(translation["fifty_fifty"])
+            self.assertTrue(translation["guaranteed"])
+            self.assertFalse(translation["head_to_head"])
+            self.assertEqual(translation["name"], "NBA $350K Bird [$350,000 Guaranteed]")
+            self.assertEqual(translation["payout"], 350000.0)
+            self.assertEqual(translation["sport"], Sport.NBA)
+            self.assertTrue(translation["starred"])
+            self.assertEqual(translation["starts_at"], datetime(2016, 11, 12, 0, 0, 0, tzinfo=pytz.UTC))


### PR DESCRIPTION
Fix issue with contest response translator and updates documentation.

This is a backwards-incompatible change but it was done to fix a bug with contest response being a list instead of a list of lists, hence the `patch` upgrade instead of a major version upgrade.

This also adds a `sport` field to the contest draft group response translation.