### PR TITLE
Create single Client class

### DIFF
--- a/draft_kings/__init__.py
+++ b/draft_kings/__init__.py
@@ -1,1 +1,2 @@
 from draft_kings.data import Sport
+from draft_kings.client import Client

--- a/tests/integration/client/test_available_players.py
+++ b/tests/integration/client/test_available_players.py
@@ -5,7 +5,7 @@ from unittest.mock import patch, Mock
 
 import pytz
 
-from draft_kings.client import available_players
+from draft_kings import Client
 from draft_kings.http_client import HTTPClient
 from draft_kings.output.objects.players import PlayerDetails, DraftDetails, PositionDetails, \
     PlayerTeamSeriesDetails, TeamSeriesDetails, ExceptionalMessageDetails, ExceptionalMessageTypeDetails
@@ -14,7 +14,7 @@ from tests.config import ROOT_DIRECTORY
 
 class TestNBAAvailablePlayers(TestCase):
     def setUp(self) -> None:
-        self.result = available_players(draft_group_id=11513)
+        self.result = Client().available_players(draft_group_id=11513)
 
     def test_get_available_players(self):
         self.assertIsNotNone(self.result)
@@ -104,7 +104,7 @@ class TestNBAAvailablePlayers(TestCase):
 
 class TestLeagueOfLegendsAvailablePlayers(TestCase):
     def setUp(self) -> None:
-        self.result = available_players(draft_group_id=26691)
+        self.result = Client().available_players(draft_group_id=26691)
 
     def test_get_available_players_league_of_legends(self):
         self.assertIsNotNone(self.result)
@@ -175,7 +175,7 @@ class TestPlayersWithExceptionalMessages(TestCase):
             patched_method = patch.object(HTTPClient, "available_players")
             mocked_method = patched_method.start()
             mocked_method.return_value = Mock(text=self.response_data)
-            self.result = available_players(draft_group_id=41793)
+            self.result = Client().available_players(draft_group_id=41793)
 
     def test_exceptional_messages(self):
         self.assertListEqual(

--- a/tests/integration/client/test_client.py
+++ b/tests/integration/client/test_client.py
@@ -1,30 +1,33 @@
 from unittest import TestCase
 
-from draft_kings.client import available_players, draft_group_details, draftables, regions, contests, countries
+from draft_kings.client import Client
 from draft_kings.data import Sport
 
 
 class TestClient(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+
     def test_get_available_players(self):
-        result = available_players(draft_group_id=11513)
+        result = self.client.available_players(draft_group_id=11513)
         self.assertIsNotNone(result)
 
     def test_get_draft_group_details(self):
-        response = draft_group_details(draft_group_id=11513)
+        response = self.client.draft_group_details(draft_group_id=11513)
         self.assertIsNotNone(response)
 
     def test_get_draftables(self):
-        response = draftables(draft_group_id=18186)
+        response = self.client.draftables(draft_group_id=18186)
         self.assertIsNotNone(response)
 
     def test_regions(self):
-        response = regions("US")
+        response = self.client.regions("US")
         self.assertIsNotNone(response)
 
     def test_countries(self):
-        response = countries()
+        response = self.client.countries()
         self.assertIsNotNone(response)
 
     def test_contests(self):
-        response = contests(Sport.NBA)
+        response = self.client.contests(Sport.NBA)
         self.assertIsNotNone(response)

--- a/tests/integration/client/test_contests.py
+++ b/tests/integration/client/test_contests.py
@@ -1,84 +1,87 @@
 from unittest import TestCase
 
-from draft_kings import client
+from draft_kings import Client
 from draft_kings.data import Sport
 
 
 class TestContests(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+
     def test_nba_contests(self):
-        result = client.contests(Sport.NBA)
+        result = self.client.contests(Sport.NBA)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_nfl_contests(self):
-        result = client.contests(Sport.NFL)
+        result = self.client.contests(Sport.NFL)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_mlb_contests(self):
-        result = client.contests(Sport.MLB)
+        result = self.client.contests(Sport.MLB)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_nhl_contests(self):
-        result = client.contests(Sport.NHL)
+        result = self.client.contests(Sport.NHL)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_nascar_contests(self):
-        result = client.contests(Sport.NASCAR)
+        result = self.client.contests(Sport.NASCAR)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_golf_contests(self):
-        result = client.contests(Sport.GOLF)
+        result = self.client.contests(Sport.GOLF)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_cfl_contests(self):
-        result = client.contests(Sport.CFL)
+        result = self.client.contests(Sport.CFL)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_college_football_contests(self):
-        result = client.contests(Sport.COLLEGE_FOOTBALL)
+        result = self.client.contests(Sport.COLLEGE_FOOTBALL)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_college_basketball_contests(self):
-        result = client.contests(Sport.COLLEGE_BASKETBALL)
+        result = self.client.contests(Sport.COLLEGE_BASKETBALL)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_mma_contests(self):
-        result = client.contests(Sport.MIXED_MARTIAL_ARTS)
+        result = self.client.contests(Sport.MIXED_MARTIAL_ARTS)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_eurloeage_basketball_contests(self):
-        result = client.contests(Sport.EUROLEAGUE_BASKETBALL)
+        result = self.client.contests(Sport.EUROLEAGUE_BASKETBALL)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_tennis_contests(self):
-        result = client.contests(Sport.TENNIS)
+        result = self.client.contests(Sport.TENNIS)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)
 
     def test_league_of_legends_contests(self):
-        result = client.contests(Sport.LEAGUE_OF_LEGENDS)
+        result = self.client.contests(Sport.LEAGUE_OF_LEGENDS)
         self.assertIsNotNone(result)
         self.assertIsNotNone(result.contests)
         self.assertIsNotNone(result.draft_groups)

--- a/tests/integration/client/test_countries.py
+++ b/tests/integration/client/test_countries.py
@@ -2,7 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
-from draft_kings import client
+from draft_kings import Client
 from draft_kings.http_client import HTTPClient
 from tests.config import ROOT_DIRECTORY
 from draft_kings.output.objects.countries import CountriesDetails, CountryDetails
@@ -10,7 +10,7 @@ from draft_kings.output.objects.countries import CountriesDetails, CountryDetail
 
 class TestCountries(TestCase):
     def setUp(self) -> None:
-        self.result = client.countries()
+        self.result = Client().countries()
 
     def test_countries_are_not_none(self):
         self.assertIsNotNone(self.result)
@@ -27,7 +27,7 @@ class TestCountiesWithMockedHTTPResponse(TestCase):
     @patch.object(HTTPClient, "countries")
     def test_countries_are_not_none(self, mocked_countries):
         mocked_countries.return_value = Mock(name="countries_response", text=self.response_data)
-        self.assertIsNotNone(client.countries())
+        self.assertIsNotNone(Client().countries())
 
     @patch.object(HTTPClient, "countries")
     def test_translated_country_details(self, mocked_countries):
@@ -91,6 +91,6 @@ class TestCountiesWithMockedHTTPResponse(TestCase):
                     )
                 ]
             ),
-            client.countries()
+            Client().countries()
         )
 

--- a/tests/integration/client/test_draft_group_details.py
+++ b/tests/integration/client/test_draft_group_details.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
-from draft_kings import client
+from draft_kings import Client
 from draft_kings.data import Sport
 from draft_kings.http_client import HTTPClient
 from draft_kings.output.objects.draft_group import LeagueDetails, GameDetails, ContestDetails, \
@@ -12,44 +12,47 @@ from tests.config import ROOT_DIRECTORY
 
 
 class TestDraftGroupDetails(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+
     def test_nba_draft_group_details(self):
         # Draft Group from 2016-11-16
-        details = client.draft_group_details(draft_group_id=11513)
+        details = self.client.draft_group_details(draft_group_id=11513)
         self.assertIsNotNone(details)
 
     def test_nhl_draft_group_details(self):
         # Draft Group for 2018-11-20
-        details = client.draft_group_details(draft_group_id=22953)
+        details = self.client.draft_group_details(draft_group_id=22953)
         self.assertIsNotNone(details)
 
     def test_nfl_draft_group_details(self):
         # Draft Group for 2018-11-20 MNF
-        details = client.draft_group_details(draft_group_id=22927)
+        details = self.client.draft_group_details(draft_group_id=22927)
         self.assertIsNotNone(details)
 
     def test_cfb_draft_group_details(self):
         # Draft Group for 2018-11-24
-        details = client.draft_group_details(draft_group_id=22952)
+        details = self.client.draft_group_details(draft_group_id=22952)
         self.assertIsNotNone(details)
 
     def test_cbb_draft_group_details(self):
         # Draft Group for 2018-11-19
-        details = client.draft_group_details(draft_group_id=22958)
+        details = self.client.draft_group_details(draft_group_id=22958)
         self.assertIsNotNone(details)
 
     def test_soccer_uefa_national_league_draft_group_details(self):
         # Draft Group for 2018-11-19
-        details = client.draft_group_details(draft_group_id=22855)
+        details = self.client.draft_group_details(draft_group_id=22855)
         self.assertIsNotNone(details)
 
     def test_soccer_epl_draft_group_details(self):
         # Start Date is 2018-11-24T15:00:00.0000000Z
-        details = client.draft_group_details(draft_group_id=22831)
+        details = self.client.draft_group_details(draft_group_id=22831)
         self.assertIsNotNone(details)
 
     def test_euroleague_draft_group_details(self):
         # Start Date is 2018-11-20T17:00:00.0000000Z
-        details = client.draft_group_details(draft_group_id=22916)
+        details = self.client.draft_group_details(draft_group_id=22916)
         self.assertIsNotNone(details)
 
 
@@ -60,7 +63,7 @@ class TestDraftGroup11513MockedHTTPResponse(TestCase):
             patched_method = patch.object(HTTPClient, "draft_group_details")
             mocked_draft_group_details = patched_method.start()
             mocked_draft_group_details.return_value = Mock(text=self.response_data)
-            self.result = client.draft_group_details(draft_group_id=11513)
+            self.result = Client().draft_group_details(draft_group_id=11513)
 
     def tearDown(self) -> None:
         patch.stopall()

--- a/tests/integration/client/test_draftables.py
+++ b/tests/integration/client/test_draftables.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
-from draft_kings import client
+from draft_kings import Client
 from draft_kings.data import Sport
 from draft_kings.http_client import HTTPClient
 from draft_kings.output.objects.draftables import PlayerNameDetails, PlayerImageDetails, PlayerCompetitionDetails, \
@@ -13,36 +13,39 @@ from tests.config import ROOT_DIRECTORY
 
 
 class TestDraftables(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+
     def test_nba_draftables(self):
-        draftables = client.draftables(draft_group_id=11513)
+        draftables = self.client.draftables(draft_group_id=11513)
         self.assertIsNotNone(draftables)
 
     def test_nhl_draftables(self):
-        draftables = client.draftables(draft_group_id=22953)
+        draftables = self.client.draftables(draft_group_id=22953)
         self.assertIsNotNone(draftables)
 
     def test_nfl_draftables(self):
-        draftables = client.draftables(draft_group_id=22927)
+        draftables = self.client.draftables(draft_group_id=22927)
         self.assertIsNotNone(draftables)
 
     def test_cfb_draftables(self):
-        draftables = client.draftables(draft_group_id=22952)
+        draftables = self.client.draftables(draft_group_id=22952)
         self.assertIsNotNone(draftables)
 
     def test_cbb_draftables(self):
-        draftables = client.draftables(draft_group_id=22958)
+        draftables = self.client.draftables(draft_group_id=22958)
         self.assertIsNotNone(draftables)
 
     def test_soccer_uefa_national_league_draftables(self):
-        draftables = client.draftables(draft_group_id=22855)
+        draftables = self.client.draftables(draft_group_id=22855)
         self.assertIsNotNone(draftables)
 
     def test_soccer_epl_draftables(self):
-        draftables = client.draftables(draft_group_id=22831)
+        draftables = self.client.draftables(draft_group_id=22831)
         self.assertIsNotNone(draftables)
 
     def test_euroleague_draftables(self):
-        draftables = client.draftables(draft_group_id=22916)
+        draftables = self.client.draftables(draft_group_id=22916)
         self.assertIsNotNone(draftables)
 
 
@@ -53,7 +56,7 @@ class TestMockedUpcomingNFLDraftablesResponse(TestCase):
             patched_method = patch.object(HTTPClient, "draftables")
             mocked_method = patched_method.start()
             mocked_method.return_value = Mock(text=self.response_data)
-            self.result = client.draftables(draft_group_id=41793)
+            self.result = Client().draftables(draft_group_id=41793)
 
     def tearDown(self) -> None:
         patch.stopall()
@@ -189,7 +192,7 @@ class TestDraftablesWithDraftAlerts(TestCase):
             patched_method = patch.object(HTTPClient, "draftables")
             mocked_method = patched_method.start()
             mocked_method.return_value = Mock(text=self.response_data)
-            self.result = client.draftables(draft_group_id=41793)
+            self.result = Client().draftables(draft_group_id=41793)
 
     def test_player_with_draft_alerts(self):
         self.assertListEqual(

--- a/tests/integration/client/test_regions.py
+++ b/tests/integration/client/test_regions.py
@@ -2,23 +2,26 @@ import os
 from unittest import TestCase
 from unittest.mock import patch, Mock
 
-from draft_kings import client
+from draft_kings import Client
 from draft_kings.http_client import HTTPClient
 from draft_kings.output.objects.regions import RegionDetails
 from tests.config import ROOT_DIRECTORY
 
 
 class TestRegions(TestCase):
+    def setUp(self) -> None:
+        self.client = Client()
+
     def test_american_regions_is_not_none(self):
-        regions = client.regions("US")
+        regions = self.client.regions("US")
         self.assertIsNotNone(regions)
 
     def test_american_regions_exist(self):
-        regions = client.regions("US")
+        regions = self.client.regions("US")
         self.assertGreater(len(regions.regions), 0)
 
     def test_first_american_region(self):
-        regions = client.regions("US")
+        regions = self.client.regions("US")
         self.assertEqual(
             RegionDetails(
                 code="AL",
@@ -30,19 +33,19 @@ class TestRegions(TestCase):
         )
 
     def test_british_regions_is_not_none(self):
-        regions = client.regions("GB")
+        regions = self.client.regions("GB")
         self.assertIsNotNone(regions)
 
     def test_british_regions_exist(self):
-        regions = client.regions("GB")
+        regions = self.client.regions("GB")
         self.assertGreater(len(regions.regions), 0)
 
     def test_canadian_regions_is_not_none(self):
-        regions = client.regions("CA")
+        regions = self.client.regions("CA")
         self.assertIsNotNone(regions)
 
     def test_canadian_regions_exist(self):
-        regions = client.regions("CA")
+        regions = self.client.regions("CA")
         self.assertGreater(len(regions.regions), 0)
 
 
@@ -53,7 +56,7 @@ class TestMockedUSResponseRegions(TestCase):
             patched_method = patch.object(HTTPClient, "regions")
             mocked_method = patched_method.start()
             mocked_method.return_value = Mock(text=self.response_data)
-            self.result = client.regions("US")
+            self.result = Client().regions("US")
 
     def tearDown(self) -> None:
         patch.stopall()


### PR DESCRIPTION
Create a single `Client` class to be imported instead of the current standalone methods.

Part of the reason is to avoid generating identical `Transformer`s as well as reusing other shared instances (like `HTTPClient`).